### PR TITLE
Use updated dashrates w/several new API sources

### DIFF
--- a/fetch/main.go
+++ b/fetch/main.go
@@ -114,6 +114,12 @@ func fetchAndStoreRates() error {
 		dashrates.NewCoinbaseProAPI(),
 		dashrates.NewCoinbaseAPI(),
 		dashrates.NewDigifinexAPI(),
+		dashrates.NewIndodaxAPI(),
+		dashrates.NewKucoinAPI(),
+		dashrates.NewBiboxAPI(),
+		dashrates.NewWhitebitAPI(),
+		dashrates.NewCointradeAPI(),
+		dashrates.NewOKExAPI(),
 	}
 
 	var wg sync.WaitGroup

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/projects/sls-dash-rate-service
 
+go 1.14
+
 require (
 	github.com/aws/aws-lambda-go v1.6.0
 	github.com/go-redis/redis v6.15.7+incompatible // indirect
-	github.com/nmarley/dashrates v0.0.0-20200220220312-c2c6bd4cceb0 // indirect
+	github.com/nmarley/dashrates v0.0.0-20200228004233-809a3785ca32 // indirect
 )
-
-go 1.13

--- a/go.sum
+++ b/go.sum
@@ -18,3 +18,5 @@ github.com/nmarley/dashrates v0.0.0-20190919180315-9f44cbf50e44 h1:H72tPJCwt8Ez0
 github.com/nmarley/dashrates v0.0.0-20190919180315-9f44cbf50e44/go.mod h1:aGouMFkZKrrcr9WF1Y/HF+2vgSsQMh2A0JsNsAiBWnQ=
 github.com/nmarley/dashrates v0.0.0-20200220220312-c2c6bd4cceb0 h1:708dweZCpLNwwZhAJqEsZLmK2mAqT2H607QnKxG5JVY=
 github.com/nmarley/dashrates v0.0.0-20200220220312-c2c6bd4cceb0/go.mod h1:aGouMFkZKrrcr9WF1Y/HF+2vgSsQMh2A0JsNsAiBWnQ=
+github.com/nmarley/dashrates v0.0.0-20200228004233-809a3785ca32 h1:WnN65+g/FPES2TIXH0CyZwSoCUCdDSvqswuaPbp8TAs=
+github.com/nmarley/dashrates v0.0.0-20200228004233-809a3785ca32/go.mod h1:aGouMFkZKrrcr9WF1Y/HF+2vgSsQMh2A0JsNsAiBWnQ=


### PR DESCRIPTION
New exchanges added are:

- Indodax
- Kucoin
- Bibox
- Whitebit
- Cointrade
- OKEx